### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,23 +2,117 @@
   "extends": [
     "config:base"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "labels": [
+      "patch",
+      "renovate-deps"
+    ]
+  },
   "vulnerabilityAlerts": {
     "enabled": true
   },
-  "automerge": true,
-  "major": {
-    "automerge": false
-  },
-  "labels": [
-    "type: dependencies",
-    "renovate"
-  ],
-  "masterIssue": true,
-  "prConcurrentLimit": 8,
-  "prHourlyLimit": 4,
-  "timezone": "America/New_York",
-  "schedule": [
-    "every weekend"
+  "packageRules": [
+    {
+      "groupName": "dependencies",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "depTypeList": [
+        "dependencies"
+      ],
+      "labels": [
+        "minor",
+        "renovate-deps"
+      ]
+    },
+    {
+      "groupName": "dependencies",
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "depTypeList": [
+        "dependencies"
+      ],
+      "labels": [
+        "patch",
+        "renovate-deps"
+      ]
+    },
+    {
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "matchPackageNames": [
+        "@vercel/ncc"
+      ],
+      "labels": [
+        "patch",
+        "renovate-deps"
+      ]
+    },
+    {
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "excludePackageNames": [
+        "@vercel/ncc",
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "labels": [
+        "no release",
+        "renovate-deps"
+      ],
+      "automerge": true
+    },
+    {
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "labels": [
+        "no release",
+        "renovate-deps"
+      ],
+      "automerge": true
+    },
+    {
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "labels": [
+        "no release",
+        "renovate-deps"
+      ]
+    },
+    {
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "labels": [
+        "patch",
+        "renovate-deps"
+      ]
+    }
   ],
   "github-actions": {
     "enabled": true,


### PR DESCRIPTION
Hmm, renovate does not run in this repo at all. Let's sync the config and make it similar to our other public repo configs. The eventual goal is to keep `actions/core` up-to-date